### PR TITLE
Track debate LLM selection

### DIFF
--- a/prisma/migrations/20250604084829_add_llm_fields/migration.sql
+++ b/prisma/migrations/20250604084829_add_llm_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "debates" ADD COLUMN "llmModel" TEXT;
+ALTER TABLE "debates" ADD COLUMN "llmProvider" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,6 +92,8 @@ model Debate {
   pointsEarned    Float?
   summaryArticle  String?
   completedAt     DateTime?
+  llmProvider     String?
+  llmModel        String?
 
   user            User     @relation(fields: [userId], references: [userId], onDelete: Cascade)
   topic           Topic    @relation(fields: [topicId], references: [topicId], onDelete: Cascade)

--- a/src/app/api/debates/route.ts
+++ b/src/app/api/debates/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: Request) {
 
     try {
         const body = await request.json();
-        const { topicId, goalDirection } = body;
+        const { topicId, goalDirection, llmProvider, llmModel } = body;
 
         const parsedTopicId = parseInt(topicId, 10);
 
@@ -44,6 +44,8 @@ export async function POST(request: Request) {
                 initialStance: topic.currentStance,
                 goalDirection: goalDirection,
                 status: 'active',
+                llmProvider: llmProvider ?? 'openai',
+                llmModel: llmModel ?? process.env.OPENAI_MODEL_NAME ?? 'gpt-4o-mini',
             },
         });
 


### PR DESCRIPTION
## Summary
- add llmProvider and llmModel fields to Debate model
- store provider/model when creating debates
- persist provider/model on first argument if missing
- expose values in debate API and initialize selector defaults
- show LLMSelector in debate page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840077ffbd88322addd719304f00050