### PR TITLE
Make topic creation LLM configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ OPENAI_SUMMARY_MODEL_NAME=gpt-4o-mini
 DEFAULT_LLM_PROVIDER=openai
 DEFAULT_LLM_MODEL=gpt-4o-mini
 
+# LLM settings for topic creation
+TOPIC_LLM_PROVIDER=openai
+TOPIC_LLM_MODEL=gpt-4o-mini
+
 # Ollama configuration
 NEXT_PUBLIC_OLLAMA_API_BASE=http://localhost:11434
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Create a `.env` file based on the provided `.env.example`. Key variables include
 
 - `DEFAULT_LLM_PROVIDER` – initial provider for AI interactions (`openai` or `ollama`)
 - `DEFAULT_LLM_MODEL` – default model name used when no selection is made
+- `TOPIC_LLM_PROVIDER` – provider used when generating a topic's initial stance
+- `TOPIC_LLM_MODEL` – model name used for topic creation
 
 Other variables configure OpenAI credentials, Ollama connection and database paths. See `.env.example` for the full list.
 


### PR DESCRIPTION
## Summary
- allow configuring LLM provider/model for topic creation
- add TOPIC_LLM_PROVIDER and TOPIC_LLM_MODEL env vars
- implement `getAiInitialStance` helper supporting OpenAI and Ollama
- use new helper in topic creation route

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840169957a08322aaec88c06da3b37e