### PR TITLE
Unify LLM settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,10 @@ OPENAI_API_KEY=
 OPENAI_MODEL_NAME=gpt-4o-mini
 OPENAI_SUMMARY_MODEL_NAME=gpt-4o-mini
 
-# Default LLM selection
+# Default LLM selection (applies to topic creation and debates)
 DEFAULT_LLM_PROVIDER=openai
 DEFAULT_LLM_MODEL=gpt-4o-mini
 
-# LLM settings for topic creation
-TOPIC_LLM_PROVIDER=openai
-TOPIC_LLM_MODEL=gpt-4o-mini
 
 # Ollama configuration
 NEXT_PUBLIC_OLLAMA_API_BASE=http://localhost:11434

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 
 Create a `.env` file based on the provided `.env.example`. Key variables include:
 
-- `DEFAULT_LLM_PROVIDER` – initial provider for AI interactions (`openai` or `ollama`)
-- `DEFAULT_LLM_MODEL` – default model name used when no selection is made
-- `TOPIC_LLM_PROVIDER` – provider used when generating a topic's initial stance
-- `TOPIC_LLM_MODEL` – model name used for topic creation
+- `DEFAULT_LLM_PROVIDER` – provider used for both topic creation and debates (`openai` or `ollama`)
+- `DEFAULT_LLM_MODEL` – model name used when no specific model is selected
 
 Other variables configure OpenAI credentials, Ollama connection and database paths. See `.env.example` for the full list.
+
+The selected provider and model can also be changed globally from the **AI Settings** menu in the header. These settings apply to both topic creation and debates.
 
 ## Learn More
 

--- a/src/app/debates/[debateId]/page.tsx
+++ b/src/app/debates/[debateId]/page.tsx
@@ -11,6 +11,7 @@ import ReactMarkdown from 'react-markdown'; // Use correct import
 import remarkGfm from 'remark-gfm';
 import Link from 'next/link';
 import LLMSelector from '@/components/LLMSelector';
+import { useLLMSettings } from '@/components/LLMSettingsContext';
 import type { Pluggable } from 'unified'; // Import Pluggable type for plugins
 import type { Prisma } from '@prisma/client'; // Keep Prisma import if needed by other types
 
@@ -83,8 +84,9 @@ export default function DebatePage() {
     const [newArgumentText, setNewArgumentText] = useState('');
     const [isSubmittingArgument, setIsSubmittingArgument] = useState(false);
     const [argumentError, setArgumentError] = useState<string | null>(null);
-    const [selectedProvider, setSelectedProvider] = useState<'openai' | 'ollama'>('openai');
-    const [selectedModel, setSelectedModel] = useState<string>('gpt-4o-mini');
+    const { provider, model } = useLLMSettings();
+    const [selectedProvider, setSelectedProvider] = useState<'openai' | 'ollama'>(provider);
+    const [selectedModel, setSelectedModel] = useState<string>(model);
 
     const handleModelSelect = (provider: 'openai' | 'ollama', model: string) => {
         setSelectedProvider(provider);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import SessionProviderWrapper from "@/components/SessionProviderWrapper";
 import Header from "@/components/Header";
 import { ThemeProvider } from "@/components/ThemeProvider";
+import { LLMSettingsProvider } from "@/components/LLMSettingsContext";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -27,13 +28,15 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <SessionProviderWrapper>
-            <Header />
-            {/* Remove container/padding from main if you want full-width bg */}
-            <main className="container mx-auto p-4">
-              {children}
-            </main>
-          </SessionProviderWrapper>
+          <LLMSettingsProvider>
+            <SessionProviderWrapper>
+              <Header />
+              {/* Remove container/padding from main if you want full-width bg */}
+              <main className="container mx-auto p-4">
+                {children}
+              </main>
+            </SessionProviderWrapper>
+          </LLMSettingsProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/Debates/ArgumentInput.tsx
+++ b/src/components/Debates/ArgumentInput.tsx
@@ -1,6 +1,7 @@
 import { useState, FormEvent } from 'react';
 import Link from 'next/link';
 import LLMSelector from '@/components/LLMSelector';
+import { useLLMSettings } from '@/components/LLMSettingsContext';
 
 interface Props {
     isMyTurn: boolean;
@@ -22,10 +23,11 @@ export default function ArgumentInput({
     const [currentArgument, setCurrentArgument] = useState('');
     const [isSubmittingArgument, setIsSubmittingArgument] = useState(false);
     const [argumentSubmitMessage, setArgumentSubmitMessage] = useState('');
+    const { provider, model } = useLLMSettings();
 
     // Added LLM selection state
-    const [selectedProvider, setSelectedProvider] = useState<'openai' | 'ollama'>('openai');
-    const [selectedModel, setSelectedModel] = useState<string>('gpt-4o-mini');
+    const [selectedProvider, setSelectedProvider] = useState<'openai' | 'ollama'>(provider);
+    const [selectedModel, setSelectedModel] = useState<string>(model);
 
     const handleModelSelect = (provider: 'openai' | 'ollama', model: string) => {
         setSelectedProvider(provider);

--- a/src/components/GlobalLLMSelector.tsx
+++ b/src/components/GlobalLLMSelector.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import LLMSelector from "./LLMSelector";
+import { useLLMSettings } from "./LLMSettingsContext";
+
+export default function GlobalLLMSelector() {
+  const { provider, model, setProvider, setModel } = useLLMSettings();
+
+  const handleSelect = (p: "openai" | "ollama", m: string) => {
+    setProvider(p);
+    setModel(m);
+  };
+
+  return (
+    <LLMSelector
+      onModelSelect={handleSelect}
+      defaultProvider={provider}
+      defaultModel={model}
+    />
+  );
+}
+

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { useSession, signOut } from 'next-auth/react';
 import { useState, useEffect } from 'react';
 import { useTheme } from 'next-themes';
 import type { Notification } from '@prisma/client';
+import GlobalLLMSelector from './GlobalLLMSelector';
 
 // Define expected fields from notification
 type NotificationData = Pick<Notification, 'notificationId' | 'content' | 'createdAt' | 'isRead' | 'notificationType' | 'relatedDebateId' | 'relatedUserId' | 'relatedCommentId'>;
@@ -17,6 +18,7 @@ export default function Header() {
     const [showNotifications, setShowNotifications] = useState(false);
     const [loadingNotifications, setLoadingNotifications] = useState(false);
     const [markingRead, setMarkingRead] = useState(false);
+    const [showLLMSettings, setShowLLMSettings] = useState(false);
 
     // Theme handling
     const { theme, setTheme } = useTheme();
@@ -55,6 +57,10 @@ export default function Header() {
 
     const handleToggleNotifications = () => {
         setShowNotifications(prev => !prev);
+    };
+
+    const handleToggleLLMSettings = () => {
+        setShowLLMSettings(prev => !prev);
     };
 
     const handleMarkAllRead = async () => {
@@ -100,6 +106,21 @@ export default function Header() {
 
                 <div className="flex items-center space-x-4">
                     <Link href="/leaderboard" className="text-sm text-gray-600 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400">Leaderboard</Link>
+
+                    {/* Global LLM Settings */}
+                    <div className="relative">
+                        <button
+                            onClick={handleToggleLLMSettings}
+                            className="text-sm text-gray-600 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400"
+                        >
+                            AI Settings
+                        </button>
+                        {showLLMSettings && (
+                            <div className="absolute right-0 mt-2 z-20 bg-white dark:bg-gray-700 p-2 border rounded shadow">
+                                <GlobalLLMSelector />
+                            </div>
+                        )}
+                    </div>
 
                     {/* Theme Toggle - only show icon after component is mounted */}
                     <button

--- a/src/components/LLMSettingsContext.tsx
+++ b/src/components/LLMSettingsContext.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+
+type ProviderType = 'openai' | 'ollama';
+
+interface LLMSettingsContextValue {
+  provider: ProviderType;
+  model: string;
+  setProvider: (p: ProviderType) => void;
+  setModel: (m: string) => void;
+}
+
+const envDefaultProvider: ProviderType =
+  process.env.DEFAULT_LLM_PROVIDER === 'ollama' ? 'ollama' : 'openai';
+const envDefaultModel = process.env.DEFAULT_LLM_MODEL || 'gpt-4o-mini';
+
+const LLMSettingsContext = createContext<LLMSettingsContextValue>({
+  provider: envDefaultProvider,
+  model: envDefaultModel,
+  setProvider: () => {},
+  setModel: () => {},
+});
+
+export function LLMSettingsProvider({ children }: { children: ReactNode }) {
+  const [provider, setProvider] = useState<ProviderType>(envDefaultProvider);
+  const [model, setModel] = useState<string>(envDefaultModel);
+
+  return (
+    <LLMSettingsContext.Provider value={{ provider, model, setProvider, setModel }}>
+      {children}
+    </LLMSettingsContext.Provider>
+  );
+}
+
+export function useLLMSettings() {
+  return useContext(LLMSettingsContext);
+}
+

--- a/src/components/Topics/CreateTopicForm.tsx
+++ b/src/components/Topics/CreateTopicForm.tsx
@@ -3,6 +3,7 @@
 
 import { useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
+import { useLLMSettings } from '@/components/LLMSettingsContext';
 // Auth check is done on the API side
 
 export default function CreateTopicForm() {
@@ -11,6 +12,7 @@ export default function CreateTopicForm() {
     const [category, setCategory] = useState('');
     const [message, setMessage] = useState('');
     const router = useRouter();
+    const { provider, model } = useLLMSettings();
 
     // No need for client-side session check if API requires auth
     // const { status } = useSession();
@@ -25,7 +27,13 @@ export default function CreateTopicForm() {
             const response = await fetch('/api/topics', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name, description, category }),
+                body: JSON.stringify({
+                    name,
+                    description,
+                    category,
+                    llmProvider: provider,
+                    llmModel: model
+                }),
             });
             const data = await response.json();
             if (!response.ok) {

--- a/src/lib/aiService.ts
+++ b/src/lib/aiService.ts
@@ -13,11 +13,6 @@ const defaultOpenAIModel = process.env.OPENAI_MODEL_NAME || 'gpt-4o-mini';
 const defaultLLMModel = process.env.DEFAULT_LLM_MODEL || defaultOpenAIModel;
 const summaryModel = process.env.OPENAI_SUMMARY_MODEL_NAME || defaultOpenAIModel;
 
-// Defaults specifically for topic creation
-const topicLLMProvider = process.env.TOPIC_LLM_PROVIDER === 'ollama'
-    ? 'ollama'
-    : defaultLLMProvider;
-const topicLLMModel = process.env.TOPIC_LLM_MODEL || defaultLLMModel;
 
 // --- Types for getAiInitialStance ---
 export interface InitialStanceInput {
@@ -41,8 +36,8 @@ export async function getAiInitialStance(
     const {
         topicName,
         topicDescription,
-        llmProvider = topicLLMProvider,
-        llmModel = topicLLMModel
+        llmProvider = defaultLLMProvider,
+        llmModel = defaultLLMModel
     } = input;
 
     let stance = 5.0;


### PR DESCRIPTION
## Summary
- drop deprecated topic-specific LLM variables
- default initial stance logic to `DEFAULT_LLM_PROVIDER` and `DEFAULT_LLM_MODEL`
- add global LLM settings context and selector
- allow topic creation to send selected provider/model
- expose global AI settings menu in the header

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68401b7c922083229475326da1b123e2