### PR TITLE
Fix LLM selector dropdown behaviour

### DIFF
--- a/src/components/GlobalLLMSelector.tsx
+++ b/src/components/GlobalLLMSelector.tsx
@@ -2,13 +2,26 @@
 
 import LLMSelector from "./LLMSelector";
 import { useLLMSettings } from "./LLMSettingsContext";
+import { useRef } from "react";
 
-export default function GlobalLLMSelector() {
+interface GlobalLLMSelectorProps {
+  onSelectDone?: () => void;
+}
+
+export default function GlobalLLMSelector({
+  onSelectDone,
+}: GlobalLLMSelectorProps) {
   const { provider, model, setProvider, setModel } = useLLMSettings();
+  const firstRender = useRef(true);
 
   const handleSelect = (p: "openai" | "ollama", m: string) => {
     setProvider(p);
     setModel(m);
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    onSelectDone?.();
   };
 
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -117,7 +117,7 @@ export default function Header() {
                         </button>
                         {showLLMSettings && (
                             <div className="absolute right-0 mt-2 z-20 bg-white dark:bg-gray-700 p-2 border rounded shadow">
-                                <GlobalLLMSelector />
+                                <GlobalLLMSelector onSelectDone={() => setShowLLMSettings(false)} />
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
## Summary
- allow `GlobalLLMSelector` to notify when selection completes
- close AI Settings dropdown once a provider/model is chosen
- avoid closing the dropdown on initial render

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840246a00348322a29ba3db570352d0