### PR TITLE
Introduce Prisma singleton and update API routes

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import bcrypt from 'bcrypt';
 import { createHmac } from 'crypto';
 
@@ -21,7 +21,6 @@ function signJwt(payload: Record<string, unknown>, secret: string, expiresIn = 3
     return `${data}.${signatureEncoded}`;
 }
 
-const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
     try {
@@ -69,6 +68,6 @@ export async function POST(request: Request) {
         console.error('Login error:', error);
         return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
     } finally {
-        await prisma.$disconnect();
+        // No disconnect for shared Prisma instance
     }
 }

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import bcrypt from 'bcrypt';
 
-const prisma = new PrismaClient();
 const saltRounds = 10; // Cost factor for bcrypt
 
 export async function POST(request: Request) {
@@ -46,6 +45,6 @@ export async function POST(request: Request) {
         console.error('Registration error:', error);
         return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
     } finally {
-        await prisma.$disconnect(); // Disconnect Prisma client
+        // No disconnect for shared Prisma instance
     }
 }

--- a/src/app/api/debates/[debateId]/comments/route.ts
+++ b/src/app/api/debates/[debateId]/comments/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient, Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/authOptions";
 
-const prisma = new PrismaClient();
 
 interface RouteParams {
     debateId: string;

--- a/src/app/api/debates/[debateId]/route.ts
+++ b/src/app/api/debates/[debateId]/route.ts
@@ -1,13 +1,13 @@
 // src/app/api/debates/[debateId]/route.ts (Updated with LLM provider selection)
 import { NextResponse } from 'next/server';
-import { PrismaClient, Argument } from '@prisma/client';
+import { Argument } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/authOptions";
 
 // Import functions from service files
 import { getAiDebateResponse, generateAndSaveSummary, AiResponseInput } from '@/lib/aiService';
 
-const prisma = new PrismaClient();
 
 // Type Definitions
 interface RouteParams { debateId: string; }

--- a/src/app/api/debates/route.ts
+++ b/src/app/api/debates/route.ts
@@ -1,10 +1,9 @@
 // src/app/api/debates/route.ts
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/authOptions"; // Import configured options
 
-const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
     // Use configured authOptions

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '@/lib/prisma';
 const LEADERBOARD_LIMIT = 20;
 
 // Removed unused 'request' parameter

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/authOptions";
 
-const prisma = new PrismaClient();
 
 // Removed unused 'request' parameter
 export async function GET() {

--- a/src/app/api/topics/[topicId]/route.ts
+++ b/src/app/api/topics/[topicId]/route.ts
@@ -1,10 +1,10 @@
 // src/app/api/topics/[topicId]/route.ts
 import { NextResponse } from 'next/server';
-import { PrismaClient, Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/authOptions";
 
-const prisma = new PrismaClient();
 
 // Define interfaces for route context and params
 interface RouteParams { topicId: string; }

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -1,11 +1,11 @@
 // src/app/api/topics/route.ts
 import { NextResponse } from 'next/server';
-import { PrismaClient, Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/authOptions";
 import { getAiInitialStance } from '@/lib/aiService';
 
-const prisma = new PrismaClient();
 
 // --- POST function (Saves scaleDefinitions if valid) ---
 export async function POST(request: Request) {

--- a/src/app/api/users/[userId]/follow/route.ts
+++ b/src/app/api/users/[userId]/follow/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient, Prisma } from '@prisma/client'; // Import Prisma for types
+import { Prisma } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/authOptions";
 
-const prisma = new PrismaClient();
 
 interface RouteParams {
     userId: string; // ID of the user being followed/unfollowed

--- a/src/app/api/users/[userId]/profile/route.ts
+++ b/src/app/api/users/[userId]/profile/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient, Prisma } from '@prisma/client'; // Import Prisma namespace
+import { Prisma } from '@prisma/client';
+import prisma from '@/lib/prisma';
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/authOptions";
 
-const prisma = new PrismaClient();
 
 interface RouteParams {
     userId: string;

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+    globalForPrisma.prisma = prisma;
+}
+
+export default prisma;


### PR DESCRIPTION
## Summary
- create a shared Prisma client in `src/lib/prisma.ts`
- replace inline `PrismaClient` instantiation in API routes with the shared client
- drop disconnect calls in login and register routes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851374b72388322aa934f0d04ff5011