### PR TITLE
Add section on running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ Other variables configure OpenAI credentials, Ollama connection and database pat
 
 The selected provider and model can also be changed globally from the **AI Settings** menu in the header. These settings apply to both topic creation and debates.
 
+## Running Tests
+
+Make sure all dependencies are installed:
+
+```bash
+npm install
+```
+
+Then run the Jest unit tests with:
+
+```bash
+npm test
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
## Summary
- add documentation for running Jest tests in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685139e5ff808322bea153541689c4e4