### PR TITLE
Fix point allocation

### DIFF
--- a/src/app/api/debates/[debateId]/route.ts
+++ b/src/app/api/debates/[debateId]/route.ts
@@ -252,6 +252,12 @@ export async function POST(request: Request, context: RouteContext) {
                 }
             });
 
+            // Update user's total points
+            await prisma.user.update({
+                where: { userId: userId },
+                data: { totalPoints: { increment: pointsThisTurn } }
+            });
+
             // Update topic stance
             await prisma.topic.update({
                 where: { topicId: debateTopicId },


### PR DESCRIPTION
## Summary
- increment a user's `totalPoints` when stance shifts award points

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853cc89acd48322a913ccdd636ae78f