### PR TITLE
Limit characters per debate turn

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,7 @@ NEXTAUTH_URL=http://localhost:3000
 
 # Secret used for manual login route
 JWT_SECRET=
+
+# Debate settings
+MAX_ARGUMENT_CHARS=1000
+NEXT_PUBLIC_MAX_ARGUMENT_CHARS=1000

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Create a `.env` file based on the provided `.env.example`. Key variables include
 
 - `DEFAULT_LLM_PROVIDER` – provider used for both topic creation and debates (`openai` or `ollama`)
 - `DEFAULT_LLM_MODEL` – model name used when no specific model is selected
+- `MAX_ARGUMENT_CHARS` – maximum characters allowed per argument
 
 Other variables configure OpenAI credentials, Ollama connection and database paths. See `.env.example` for the full list.
 

--- a/src/app/api/debates/[debateId]/route.ts
+++ b/src/app/api/debates/[debateId]/route.ts
@@ -4,6 +4,7 @@ import { Argument } from '@prisma/client';
 import prisma from '@/lib/prisma';
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/authOptions";
+import { MAX_ARGUMENT_CHARS } from '@/lib/constants';
 
 // Import functions from service files
 import { getAiDebateResponse, generateAndSaveSummary, AiResponseInput } from '@/lib/aiService';
@@ -100,7 +101,9 @@ export async function POST(request: Request, context: RouteContext) {
         if (!argumentText?.trim()) {
             return NextResponse.json({ error: 'Argument text is required' }, { status: 400 });
         }
-
+        if (argumentText.trim().length > MAX_ARGUMENT_CHARS) {
+            return NextResponse.json({ error: `Argument exceeds ${MAX_ARGUMENT_CHARS} character limit` }, { status: 400 });
+        }
         // --- Step 1: Transaction (Fetch history, Save user arg) ---
         const transactionResult = await prisma.$transaction<TransactionResult>(async (tx) => {
             // Get debate with existing arguments

--- a/src/app/debates/[debateId]/page.tsx
+++ b/src/app/debates/[debateId]/page.tsx
@@ -12,6 +12,7 @@ import remarkGfm from 'remark-gfm';
 import Link from 'next/link';
 import { useLLMSettings } from '@/components/LLMSettingsContext';
 import type { Pluggable } from 'unified'; // Import Pluggable type for plugins
+import { MAX_ARGUMENT_CHARS } from '@/lib/constants';
 // --- Define expected data structure (Helper Types) ---
 type UserSnippet = {
     userId: number;
@@ -236,6 +237,7 @@ export default function DebatePage() {
         event.preventDefault(); // Prevent page reload
         // Basic validation and turn check
         if (!newArgumentText.trim()) { setArgumentError("Argument cannot be empty."); return; }
+        if (newArgumentText.trim().length > MAX_ARGUMENT_CHARS) { setArgumentError(`Argument exceeds ${MAX_ARGUMENT_CHARS} character limit.`); return; }
         // Ensure debate exists before accessing properties
         if (!session?.user?.id || !debate || parseInt(session.user.id, 10) !== debate.user.userId) {
             setArgumentError("Cannot submit argument: Not logged in or not your debate turn.");

--- a/src/components/Debates/ArgumentInput.tsx
+++ b/src/components/Debates/ArgumentInput.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import LLMSelector from '@/components/LLMSelector';
 import { useLLMSettings } from '@/components/LLMSettingsContext';
 
+import { MAX_ARGUMENT_CHARS } from "@/lib/constants";
 interface Props {
     isMyTurn: boolean;
     debateId: number;
@@ -37,6 +38,10 @@ export default function ArgumentInput({
     const handleArgumentSubmit = async (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (!currentArgument.trim() || isSubmittingArgument || isNaN(debateId)) return;
+        if (currentArgument.trim().length > MAX_ARGUMENT_CHARS) {
+            setArgumentSubmitMessage(`Error: Argument exceeds ${MAX_ARGUMENT_CHARS} character limit.`);
+            return;
+        }
 
         setIsSubmittingArgument(true);
         setArgumentSubmitMessage(`Submitting argument to ${selectedProvider} (${selectedModel})...`);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,4 @@
+export const MAX_ARGUMENT_CHARS = parseInt(
+  process.env.NEXT_PUBLIC_MAX_ARGUMENT_CHARS || process.env.MAX_ARGUMENT_CHARS || '1000',
+  10
+);


### PR DESCRIPTION
## Summary
- document new environment variable `MAX_ARGUMENT_CHARS`
- add MAX_ARGUMENT_CHARS to `.env.example`
- enforce argument length limit in debate API
- validate argument length on the client
- expose constant via new `src/lib/constants.ts`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853cd25696083228edf482985e12733