### PR TITLE
Improve debate page clarity

### DIFF
--- a/src/app/debates/[debateId]/page.tsx
+++ b/src/app/debates/[debateId]/page.tsx
@@ -13,6 +13,7 @@ import Link from 'next/link';
 import { useLLMSettings } from '@/components/LLMSettingsContext';
 import type { Pluggable } from 'unified'; // Import Pluggable type for plugins
 import { MAX_ARGUMENT_CHARS } from '@/lib/constants';
+import StanceIndicator from '@/components/Debates/StanceIndicator';
 // --- Define expected data structure (Helper Types) ---
 type UserSnippet = {
     userId: number;
@@ -290,6 +291,10 @@ export default function DebatePage() {
     // Calculate flags *after* confirming debate is not null
     const loggedInUserId = session?.user?.id ? parseInt(session.user.id, 10) : null;
     const isOwner = loggedInUserId === debate.user.userId; // Safe access
+    // Determine the AI's current stance based on debate progress
+    const lastArgument = debate.arguments[debate.arguments.length - 1];
+    const currentStance = debate.finalStance ?? (lastArgument ? (lastArgument.stanceAfter ?? lastArgument.stanceBefore) : debate.initialStance);
+    const userGoalStance = debate.goalDirection === 'left' ? 0 : 10;
     // *** Use Corrected Turn Logic ***
     const canSubmitArgument = debate.status === 'active' &&
         isOwner &&
@@ -324,6 +329,13 @@ export default function DebatePage() {
                 {debate.status === 'completed' && debate.pointsEarned !== null && (
                     <p className="text-lg font-medium">Points Earned: {debate.pointsEarned.toFixed(1)}</p>
                 )}
+                <p className="text-sm text-gray-500 dark:text-gray-500">AI Initial Stance: {debate.initialStance.toFixed(1)}/10</p>
+                <p className="text-sm text-gray-500 dark:text-gray-500">Your Goal Position: {userGoalStance}/10</p>
+                <StanceIndicator
+                    currentStance={currentStance}
+                    initialStance={debate.initialStance}
+                    status={debate.status}
+                />
             </div>
 
             {/* Delete Button (Conditional) */}


### PR DESCRIPTION
## Summary
- add stance indicator import
- compute current AI stance and user goal stance
- display starting stance, user goal, and stance indicator in header

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d7d185b48322b3645f222e04bf0f